### PR TITLE
Reduce whitespace if row/column labels are different lengths

### DIFF
--- a/src/matrix.js
+++ b/src/matrix.js
@@ -47,8 +47,8 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   //txtLength is passed in. but names may be much smaller than this value.
   //since this informs the margin we want to set it to whichever is longer
   //this prevents a huge white space if txtlength is considerably bigger
-  //than the longest name
-  const maxTxtLength = longest.length < txtLength ? longest.length : txtLength;
+  //than the longest name. add 3 characters to account for ellipsis (...)
+  const maxTxtLength = longest.length < txtLength ? longest.length : txtLength + 3;
 
   //the user settable value cellsize controls the size of the svg.
   // var size = names.length * cellSize;

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -39,8 +39,10 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   }
 
   //find the length of the longest name. this will inform the margin and name truncation
-  var allNames = rowNames.concat(colNames);
-  var longest = allNames.reduce((a, b) => {
+  var longestColName = colNames.reduce((a, b) => {
+    return a.length > b.length ? a : b;
+  });
+  var longestRowName = rowNames.reduce((a, b) => {
     return a.length > b.length ? a : b;
   });
 
@@ -48,17 +50,18 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   //since this informs the margin we want to set it to whichever is longer
   //this prevents a huge white space if txtlength is considerably bigger
   //than the longest name. add 3 characters to account for ellipsis (...)
-  const maxTxtLength = longest.length < txtLength ? longest.length : txtLength + 3;
+  const maxColTxtLength = longestColName.length < txtLength ? longestColName.length : txtLength + 3;
+  const maxRowTxtLength = longestRowName.length < txtLength ? longestRowName.length : txtLength + 3;
 
   //the user settable value cellsize controls the size of the svg.
   // var size = names.length * cellSize;
 
   //calculate the margins needed
-  var txtOffset = maxTxtLength * txtSize * 5 + 25;
+  var colTxtOffset = maxColTxtLength * txtSize * 5 + 25;
+  var rowTxtOffset = maxRowTxtLength * txtSize * 5 + 25;
 
   // set the dimensions and margins of the graph
-  // the top has a drop shadow and needs an extra 10 pixels to display properly
-  var margin = { top: txtOffset + 10, right: 0, bottom: 0, left: txtOffset },
+  var margin = { top: colTxtOffset, right: 0, bottom: 0, left: rowTxtOffset },
     width = colNames.length * cellSize,
     height = rowNames.length * cellSize;
 
@@ -111,7 +114,7 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
     .attr('font-size', txtSize + 'em')
     .style('font-family', theme.typography.fontFamily.sansSerif)
     .attr('fill', theme.colors.text.primary)
-    .call(truncateLabel, maxTxtLength)
+    .call(truncateLabel, txtLength)
     .on('mouseover', function (event, d) {
       tooltip.html(d);
 


### PR DESCRIPTION
Currently if the row and column label sets are different, the matrix SVG in the grafana panel will be positioned based on the longest label from either set. This can lead to additional whitespace as shown in this screenshot:

<img width="1188" height="381" alt="before PR" src="https://github.com/user-attachments/assets/d5f35fcf-8bb8-44fd-99cc-38667a27c89b" />

This PR calculates separately the longest label for both rows and columns, which reduces the amount of whitespace in the panel as shown in this screenshot:

<img width="1186" height="381" alt="after PR src="https://github.com/user-attachments/assets/d1517b44-8dbe-4f11-81d2-2caab2aac197" />

I found during testing that the 10px additional whitespace applied to the top of the SVG for a drop shadow didn't seem to be required any longer so have also removed this.

I also fixed a bug where the start of the label could be drawn outside the SVG draw area in some circumstances because the ellipsis wasn't included in the label length calculation.

I've raised this PR against the 1.2.0 branch as this seems to be ahead of the master branch, if you want me to raise the PR against a different branch or have any feedback, let me know and I'll address.