### PR TITLE
Improve tooltips

### DIFF
--- a/src/matrix.js
+++ b/src/matrix.js
@@ -97,18 +97,18 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
     .attr('fill', theme.colors.text.primary)
     .call(truncateLabel, maxTxtLength)
     .on('mouseover', function (event, d) {
-      // var divSize = tooltip.node().getBoundingClientRect();  
       const tooltip = getTooltip(id, styles.tooltip);
       tooltip
         .html(d)
-        .style('left', event.pageX + 'px')
-        // .style('left', event.pageX - divSize.width + 'px')
-        //place the tooltip 5 pixels above the box they hovered
-        .style('top', event.pageY - 5 + 'px')
-        // .style('top', event.pageY - divSize.height - 5 + 'px')
         .transition()
         .duration(150)
         .style('opacity', 1);
+    })
+    .on('mousemove', function (event) {
+      const tooltip = getTooltip(id, styles.tooltip);
+      tooltip
+        .style('left', event.pageX + 5 + 'px')
+        .style('top', event.pageY + 5 + 'px')
     })
     .on('mouseout', function () {
       d3.select(this).attr('opacity', '1');
@@ -219,12 +219,16 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
 </div>`;
             return text;
           })
-          .style('left', event.pageX + 5 + 'px')
-          .style('top', event.pageY + 5 + 'px')
           .transition()
           .duration(150)
           .style('opacity', 1);
       }
+    })
+    .on('mousemove', function (event) {
+      const tooltip = getTooltip(id, styles.tooltip);
+      tooltip
+        .style('left', event.pageX + 5 + 'px')
+        .style('top', event.pageY + 5 + 'px')
     })
     .on('mouseout', function () {
       //reset the opacity and move the tooltip out of the way. If we dont move it it will prevent hovering over other boxes.


### PR DESCRIPTION
This PR makes a few different improvements to the matrix tooltips.

It first fixes a bug where quickly cycling between a grafana dashboard and an individual matrix panel in view or edit mode can cause tooltips to get stuck on the dashboard screen. The fix for this bug is to remove the tooltip div when the panel is unloaded.

Second, it applies the grafana tooltip style to matrix tooltips, to make them better fit in with the grafana visual language.

This screenshot shows the tooltips as they are currently:

<img width="397" height="381" alt="before PR" src="https://github.com/user-attachments/assets/25f1f326-9b69-4ca0-95ab-3ab5c088e7d1" />

And this screenshot shows the tooltips after this PR is applied:

<img width="395" height="381" alt="after PR" src="https://github.com/user-attachments/assets/d15ba0eb-dfa3-41bc-96af-05487a3c8efd" />

I've raised this PR against the 1.2.0 branch as this seems to be ahead of the master branch, if you want me to raise the PR against a different branch or have any feedback, let me know and I'll address.