### PR TITLE
Calculate and set fixed width/height for legend SVG

### DIFF
--- a/src/matrix.js
+++ b/src/matrix.js
@@ -246,8 +246,6 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
       .select(elem)
       .append('div')
       .attr('class', 'matrix-legend')
-      .attr('width', 'auto')
-      .attr('style', 'height: 70px;')
       .append('svg')
       .attr('id', legendClass);
 
@@ -255,6 +253,13 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
     if (options.legendType == 'range') {
       var svg = d3.select(`#${legendClass}`);
       svg
+        // legend bar starts at x=25, legend squares are 10x10, allow 9px per label character
+        .attr(
+          "width",
+          25 + ((legend.length - 1) * 10) + (legend[legend.length - 1].label.length * 9),
+        )
+        // legend label starts at y=50, allow 16px per label character
+        .attr('height', 50 + 16)
         .append('g')
         .selectAll('legendBars')
         .data(legend)
@@ -292,6 +297,14 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
 /////////// categorical - circles ////////////////////////////
       var svg = d3.select(`#${legendClass}`);
       svg
+        // legend bar starts at x=25, legend circles are drawn every 75px and have a 20px diameter,
+        // allow 9px per label character
+        .attr(
+          "width",
+          25 + ((legend.length - 1) * 75) + 20 + (legend[legend.length - 1].label.length * 9),
+        )
+        // legend label starts at y=50, allow 16px per label character
+        .attr('height', 50 + 16)
         .append('g')
         .selectAll('legendCircles')
         .data(legend)


### PR DESCRIPTION
Currently the legend SVG does not have a fixed width/height set, like the matrix SVG does, which leads to a scrollbar being shown when the legend SVG is larger than the size of the grafana panel.

This PR calculates the size of the legend based on the offset + size of the elements and applies a fixed width/height to the SVG element which eliminates the scrollbar.

A screenshot of the current behaviour:

<img width="397" height="381" alt="before PR" src="https://github.com/user-attachments/assets/20e97333-8a6a-415c-86ca-4bf799ddc6e1" />

And a screenshot of the behaviour after this PR is applied:

<img width="395" height="379" alt="after PR" src="https://github.com/user-attachments/assets/1534d3ed-97fd-4d01-8a59-fefedc1741b2" />

I've raised this PR against the 1.2.0 branch as this seems to be ahead of the master branch, if you want me to raise the PR against a different branch or have any feedback, let me know and I'll address.