### PR TITLE
Naturally sort row and column names

### DIFF
--- a/src/dataParser.ts
+++ b/src/dataParser.ts
@@ -80,8 +80,12 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
     });
   }
   // get unique set
-  const rowNames = Array.from(new Set(rows)).sort();
-  const colNames = Array.from(new Set(columns)).sort();
+  const rowNames = Array.from(new Set(rows));
+  const colNames = Array.from(new Set(columns));
+
+  // sort row/col names with natural sort
+  rowNames.sort((a, b) => a.toString().localeCompare(b.toString(), undefined, { numeric: true }));
+  colNames.sort((a, b) => a.toString().localeCompare(b.toString(), undefined, { numeric: true }));
 
   const numSquaresInMatrix = rowNames.length * colNames.length;
   if (numSquaresInMatrix > 50000) {


### PR DESCRIPTION
This PR sorts the row and column names using a natural sort.

Currently the row/column names are sorted alphabetically:
<img width="274" height="215" alt="Screenshot_20250917_180818" src="https://github.com/user-attachments/assets/28737e7b-c6cd-4ddb-b4ac-08cedc3000e9" />

This PR will make row/column names be sorted alphanumerically, which works better for hostnames:
<img width="274" height="215" alt="Screenshot_20250917_181524" src="https://github.com/user-attachments/assets/b791b8c6-7541-4d6d-9e81-bdd614e237e1" />

This fixes #10 