### PR TITLE
Make row/column/value field selection more robust

### DIFF
--- a/.levignore.js
+++ b/.levignore.js
@@ -1,0 +1,5 @@
+module.exports = {
+  changes: [
+    /PanelPlugin\.setMigrationHandler/,
+  ],
+};

--- a/src/EsnetMatrix.tsx
+++ b/src/EsnetMatrix.tsx
@@ -30,17 +30,15 @@ export const EsnetMatrix: React.FC<Props> = ({ options, data, width, height, id 
   }
 
   const ref = Matrix.matrix(
-    parsedData.rows,
-    parsedData.columns,
+    parsedData.rowNames,
+    parsedData.colNames,
     parsedData.data,
     id,
     height,
     options,
     parsedData.legend,
-    parsedData.colMetadata,
     parsedData.colCategories,
-    parsedData.rowMetadata,
-    parsedData.rowCategories
+    parsedData.rowCategories,
   );
   const thisPanelClass = `matrix-panel-${id}`;
 

--- a/src/dataParser.ts
+++ b/src/dataParser.ts
@@ -172,8 +172,46 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
 
   const rowNames: any[] = Array.from(rowNamesSet);
   const colNames: any[] = Array.from(colNamesSet);
-  const rowCategories: Category[] = Array.from(rowCategoriesMap.values());
-  const colCategories: Category[] = Array.from(colCategoriesMap.values());
+  const rowCategories: Category[] = [];
+  const colCategories: Category[] = [];
+
+  switch(options.sortType) {
+  case "natural-asc":
+  case "natural-desc":
+    const naturalSort = (a: any, b: any) => {
+      return a.toString().localeCompare(b.toString(), undefined, { numeric: true });
+    };
+
+    let sort = naturalSort;
+    if (options.sortType.endsWith("-desc")) {
+      sort = (a, b) => naturalSort(b, a);
+    }
+
+    // sort row and column headings
+    rowNames.sort(sort);
+    colNames.sort(sort);
+
+    // sort row and column categories and items in each category
+    Array.from(rowCategoriesMap.keys()).sort(sort).forEach((name) => {
+      const category = rowCategoriesMap.get(name);
+      if (category !== undefined) {
+        category.items.sort(sort);
+        rowCategories.push(category);
+      }
+    });
+    Array.from(colCategoriesMap.keys()).sort(sort).forEach((name) => {
+      const category = colCategoriesMap.get(name);
+      if (category !== undefined) {
+        category.items.sort(sort);
+        colCategories.push(category);
+      }
+    });
+    break;
+  case "none":
+    rowCategories.push(...rowCategoriesMap.values());
+    colCategories.push(...colCategoriesMap.values());
+    break;
+  }
 
   // create data matrix
   let dataMatrix: any[][] = [];

--- a/src/dataParser.ts
+++ b/src/dataParser.ts
@@ -1,4 +1,4 @@
-import { DataFrameView } from '@grafana/data';
+import { DataFrameView, Field, FieldType, getFieldDisplayName } from '@grafana/data';
 
 /**
  * this function creates an adjacency matrix to be consumed by the chord
@@ -28,25 +28,56 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
     return { rows: null, columns: null, colMetadata: [], colCategories: [], rowMetadata: [], rowCategories: [], data: null, legend: null };
   }
   // set fields
-  let sourceKey = options.sourceField;
-  let targetKey = options.targetField;
-  let colCategoryKey = options.colCategoryField;
-  let rowCategoryKey = options.rowCategoryField;
-  if (!sourceKey) {
-    sourceKey = 0;
-  }
-  if (!targetKey) {
-    targetKey = 1;
-  }
-
+  const sourceField = series.fields.find((f: Field) =>
+    options.sourceField !== undefined && (
+      options.sourceField === f.name
+      || options.sourceField === f.config?.displayNameFromDS
+      || options.sourceField === getFieldDisplayName(f)
+    )
+  ) ?? series.fields.find((f: Field) => f.type === FieldType.string);
+  const targetField = series.fields.find((f: Field) =>
+    options.targetField !== undefined && (
+      options.targetField === f.name
+      || options.targetField === f.config?.displayNameFromDS
+      || options.targetField === getFieldDisplayName(f)
+    )
+  ) ?? series.fields.find((f: Field) => f.type === FieldType.string && f.name !== sourceField?.name);
+  const colCategoryField = series.fields.find((f: Field) =>
+    options.colCategoryField !== undefined && (
+      options.colCategoryField === f.name
+      || options.colCategoryField === f.config?.displayNameFromDS
+      || options.colCategoryField === getFieldDisplayName(f)
+    )
+  );
+  const rowCategoryField = series.fields.find((f: Field) =>
+    options.rowCategoryField !== undefined && (
+      options.rowCategoryField === f.name
+      || options.rowCategoryField === f.config?.displayNameFromDS
+      || options.rowCategoryField === getFieldDisplayName(f)
+    )
+  );
   // assign valueField to the specified field or use the first number field by default
-  const val = options.valueField;
-  const valueField = val
-    ? data.series.map((series: { fields: any[] }) => series.fields.find((field: { name: any }) => field.name === val))
-    : data.series.map((series: { fields: any[] }) =>
-        series.fields.find((field: { type: string }) => field.type === 'number')
-      );
-  const valKey = valueField[0].name;
+  const valueField: any = series.fields.find((f: Field) =>
+    options.valueField !== undefined && (
+      options.valueField === f.name
+      || options.valueField === f.config?.displayNameFromDS
+      || options.valueField === getFieldDisplayName(f)
+    )
+  ) ?? series.fields.find((f: Field) => f.type === FieldType.number);
+  const sourceKey = sourceField?.name;
+  const targetKey = targetField?.name;
+  const colCategoryKey = colCategoryField?.name;
+  const rowCategoryKey = rowCategoryField?.name;
+  const valKey = valueField?.name;
+
+  if (
+    sourceKey === undefined || targetKey === undefined
+    || valueField === undefined || valKey === undefined
+  ) {
+    // no data, bail
+    console.error('no data');
+    return { rows: null, columns: null, colMetadata: [], colCategories: [], rowMetadata: [], rowCategories: [], data: null, legend: null };
+  }
 
   // function that maps value to color specified by Standard Options panel.
   // if value is null or was not returned by query, use different value
@@ -58,7 +89,7 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
     } else if (v === -1) {
       return defaultColor;
     } else {
-      return valueField[0].display(v).color;
+      return valueField.display(v).color;
     }
   }
 
@@ -95,10 +126,14 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
 
   // IF static list toggle is set, use input list
   if (options.inputList) {
-    const staticRows = options.staticRows.split(',');
-    const staticCols = options.staticColumns.split(',');
-    compositeRowKeys = Array.from(new Set(staticRows));
-    compositeColKeys = Array.from(new Set(staticCols));
+    if (options.staticRows !== undefined) {
+      const staticRows = options.staticRows.split(',');
+      compositeRowKeys = Array.from(new Set(staticRows));
+    }
+    if (options.staticColumns !== undefined) {
+      const staticCols = options.staticColumns.split(',');
+      compositeColKeys = Array.from(new Set(staticCols));
+    }
   } else {
     // Build unique composite keys from data
     const colKeySet = new Set<string>();
@@ -119,6 +154,12 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
 
     compositeColKeys = Array.from(colKeySet).sort();
     compositeRowKeys = Array.from(rowKeySet).sort();
+  }
+
+  if (compositeColKeys.length === 0 || compositeRowKeys.length === 0) {
+    // no data, bail
+    console.error('no data');
+    return { rows: null, columns: null, colMetadata: [], colCategories: [], rowMetadata: [], rowCategories: [], data: null, legend: null };
   }
 
   // Extract display names from composite keys
@@ -291,7 +332,7 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
       col: colNames[c],
       val: v,
       color: colorMap(v),
-      display: valueField[0].display(v),
+      display: valueField.display(v),
     };
   });
 
@@ -319,9 +360,9 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
     tempValues.forEach((val) => {
       // find display values, unit & color for each
       // store in array
-      let text = valueField[0].display(val).text;
-      if (valueField[0].display(val).suffix) {
-        text = text + ` ${valueField[0].display(val).suffix}`;
+      let text = valueField.display(val).text;
+      if (valueField.display(val).suffix) {
+        text = text + ` ${valueField.display(val).suffix}`;
       }
         legendData.push({
           label: text,

--- a/src/dataParser.ts
+++ b/src/dataParser.ts
@@ -1,4 +1,5 @@
 import { DataFrameView, Field, FieldType, getFieldDisplayName } from '@grafana/data';
+import { Category } from './types';
 
 /**
  * this function creates an adjacency matrix to be consumed by the chord
@@ -18,14 +19,14 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
   if (series === null || series === undefined) {
     // no data, bail
     console.error('no data');
-    return { rows: null, columns: null, colMetadata: [], colCategories: [], rowMetadata: [], rowCategories: [], data: null, legend: null };
+    return { rowNames: null, colNames: null, colCategories: [], rowCategories: [], data: null, legend: null };
   }
 
   const frame = new DataFrameView(series);
   if (frame === null || frame === undefined) {
     // no data, bail
     console.error('no data');
-    return { rows: null, columns: null, colMetadata: [], colCategories: [], rowMetadata: [], rowCategories: [], data: null, legend: null };
+    return { rowNames: null, colNames: null, colCategories: [], rowCategories: [], data: null, legend: null };
   }
   // set fields
   const sourceField = series.fields.find((f: Field) =>
@@ -76,7 +77,7 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
   ) {
     // no data, bail
     console.error('no data');
-    return { rows: null, columns: null, colMetadata: [], colCategories: [], rowMetadata: [], rowCategories: [], data: null, legend: null };
+    return { rowNames: null, colNames: null, colCategories: [], rowCategories: [], data: null, legend: null };
   }
 
   // function that maps value to color specified by Standard Options panel.
@@ -97,243 +98,104 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
   const colGrouping = !!(colCategoryKey && options.enableColGrouping);
   const rowGrouping = !!(rowCategoryKey && options.enableRowGrouping);
 
-  // Aggregation function to combine multiple values for the same cell based on user-selected method
-  // By default: aggregate is set to "sum"
-  // Falls back to "last" for non-numeric values (strings, etc.)
-  function aggregate(values: any[], method: string): any {
-    if (values.length === 0) {
-      return null;
-    }
-    // For non-numeric values, only "last" is meaningful
-    if (typeof values[0] !== 'number') {
-      return values[values.length - 1];
-    }
-    switch (method) {
-      case 'sum': return values.reduce((a: number, b: number) => a + b, 0);
-      case 'avg': return values.reduce((a: number, b: number) => a + b, 0) / values.length;
-      case 'min': return Math.min(...values);
-      case 'max': return Math.max(...values);
-      case 'last': return values[values.length - 1];
-      default: return values.reduce((a: number, b: number) => a + b, 0);
-    }
-  }
-
-  // Build composite keys from data
-  // When grouping is enabled, use "category::name" as the key to allow
-  // the same name in multiple categories. Otherwise, just use the name.
-  let compositeColKeys: string[] = [];
-  let compositeRowKeys: string[] = [];
+  // Store unique set of row and column headings/categories
+  const rowNamesSet = new Set<any>();
+  const colNamesSet = new Set<any>();
+  const rowCategoriesMap = new Map<any, Category>();
+  const colCategoriesMap = new Map<any, Category>();
 
   // IF static list toggle is set, use input list
   if (options.inputList) {
     if (options.staticRows !== undefined) {
-      const staticRows = options.staticRows.split(',');
-      compositeRowKeys = Array.from(new Set(staticRows));
+      options.staticRows.split(',').forEach((item: string) => rowNamesSet.add(item));
     }
     if (options.staticColumns !== undefined) {
-      const staticCols = options.staticColumns.split(',');
-      compositeColKeys = Array.from(new Set(staticCols));
+      options.staticColumns.split(',').forEach((item: string) => colNamesSet.add(item));
     }
   } else {
-    // Build unique composite keys from data
-    const colKeySet = new Set<string>();
-    const rowKeySet = new Set<string>();
-
+    // Collect all unique row and column headings/categories
     frame.forEach((row) => {
-      const rowName = String(row[sourceKey]);
-      const colName = String(row[targetKey]);
-      const colCat = colGrouping && row[colCategoryKey] != null ? String(row[colCategoryKey]) : '';
-      const rowCat = rowGrouping && row[rowCategoryKey] != null ? String(row[rowCategoryKey]) : '';
+      const rowName = row[sourceKey];
+      if (!rowNamesSet.has(rowName)) {
+        // new row heading
+        rowNamesSet.add(rowName);
 
-      const colKey = colGrouping ? `${colCat}::${colName}` : colName;
-      const rowKey = rowGrouping ? `${rowCat}::${rowName}` : rowName;
+        const categoryName = row[rowCategoryKey];
+        if (rowGrouping && categoryName != null) {
+          if (!rowCategoriesMap.has(categoryName)) {
+            // new row category
+            rowCategoriesMap.set(categoryName, {
+              name: categoryName,
+              items: [rowName],
+            });
+          } else {
+            // append row heading to existing row category
+            const category = rowCategoriesMap.get(categoryName);
+            category?.items.push(rowName);
+          }
+        }
+      }
 
-      colKeySet.add(colKey);
-      rowKeySet.add(rowKey);
+      const colName = row[targetKey];
+      if (!colNamesSet.has(colName)) {
+        // new column heading
+        colNamesSet.add(colName);
+
+        const categoryName = row[colCategoryKey];
+        if (colGrouping && categoryName != null) {
+          if (!colCategoriesMap.has(categoryName)) {
+            // new column category
+            colCategoriesMap.set(categoryName, {
+              name: categoryName,
+              items: [colName],
+            });
+          } else {
+            // append column heading to existing column category
+            const category = colCategoriesMap.get(categoryName);
+            category?.items.push(colName);
+          }
+        }
+      }
     });
-
-    compositeColKeys = Array.from(colKeySet).sort();
-    compositeRowKeys = Array.from(rowKeySet).sort();
   }
 
-  if (compositeColKeys.length === 0 || compositeRowKeys.length === 0) {
+  if (rowNamesSet.size === 0 || colNamesSet.size === 0) {
     // no data, bail
     console.error('no data');
-    return { rows: null, columns: null, colMetadata: [], colCategories: [], rowMetadata: [], rowCategories: [], data: null, legend: null };
+    return { rowNames: null, colNames: null, colCategories: [], rowCategories: [], data: null, legend: null };
   }
 
-  // Extract display names from composite keys
-  let colNames = compositeColKeys.map((k) => colGrouping && k.includes('::') ? k.split('::').slice(1).join('::') : k);
-  let rowNames = compositeRowKeys.map((k) => rowGrouping && k.includes('::') ? k.split('::').slice(1).join('::') : k);
-
-  // Build column metadata and category groupings
-  let colMetadata: any[] = [];
-  let colCategories: any[] = [];
-
-  if (colGrouping) {
-    // Group columns by category using composite keys
-    const categoryToColumns = new Map<string, Array<{ name: string; key: string }>>();
-
-    compositeColKeys.forEach((key) => {
-      const [cat, ...nameParts] = key.split('::');
-      const name = nameParts.join('::');
-      if (!categoryToColumns.has(cat)) {
-        categoryToColumns.set(cat, []);
-      }
-      categoryToColumns.get(cat)!.push({ name, key });
-    });
-
-    // Build CategoryGroup array (sorted by category name)
-    const sortedCategories = Array.from(categoryToColumns.keys()).sort();
-    let globalIndex = 0;
-
-    sortedCategories.forEach((catName) => {
-      const columnsInCat = categoryToColumns.get(catName)!;
-      colCategories.push({
-        name: catName,
-        columns: columnsInCat.map((c) => c.name),
-        startIndex: globalIndex,
-        endIndex: globalIndex + columnsInCat.length - 1,
-      });
-      globalIndex += columnsInCat.length;
-    });
-
-    // Build ColumnInfo array and re-order colNames/compositeColKeys to match grouped order
-    const reorderedColKeys: string[] = [];
-    const reorderedColNames: string[] = [];
-    colCategories.forEach((cat: any, catIndex: number) => {
-      cat.columns.forEach((colName: string, indexInCat: number) => {
-        colMetadata.push({
-          name: colName,
-          category: cat.name,
-          categoryIndex: catIndex,
-          indexInCategory: indexInCat,
-        });
-        reorderedColKeys.push(`${cat.name}::${colName}`);
-        reorderedColNames.push(colName);
-      });
-    });
-
-    compositeColKeys = reorderedColKeys;
-    colNames = reorderedColNames;
-  } else {
-    // No categories: create default metadata
-    colMetadata = colNames.map((name: string, idx: number) => ({
-      name,
-      category: '',
-      categoryIndex: 0,
-      indexInCategory: idx,
-    }));
-  }
-
-  // Build row metadata and row category groupings
-  let rowMetadata: any[] = [];
-  let rowCategories: any[] = [];
-
-  if (rowGrouping) {
-    // Group rows by category using composite keys
-    const categoryToRows = new Map<string, Array<{ name: string; key: string }>>();
-
-    compositeRowKeys.forEach((key) => {
-      const [cat, ...nameParts] = key.split('::');
-      const name = nameParts.join('::');
-      if (!categoryToRows.has(cat)) {
-        categoryToRows.set(cat, []);
-      }
-      categoryToRows.get(cat)!.push({ name, key });
-    });
-
-    // Build RowCategoryGroup array (sorted by category name)
-    const sortedRowCategories = Array.from(categoryToRows.keys()).sort();
-    let globalRowIndex = 0;
-
-    sortedRowCategories.forEach((catName) => {
-      const rowsInCat = categoryToRows.get(catName)!;
-      rowCategories.push({
-        name: catName,
-        rows: rowsInCat.map((r) => r.name),
-        startIndex: globalRowIndex,
-        endIndex: globalRowIndex + rowsInCat.length - 1,
-      });
-      globalRowIndex += rowsInCat.length;
-    });
-
-    // Build RowInfo array and re-order rowNames/compositeRowKeys to match grouped order
-    const reorderedRowKeys: string[] = [];
-    const reorderedRowNames: string[] = [];
-    rowCategories.forEach((cat: any, catIndex: number) => {
-      cat.rows.forEach((rowName: string, indexInCat: number) => {
-        rowMetadata.push({
-          name: rowName,
-          category: cat.name,
-          categoryIndex: catIndex,
-          indexInCategory: indexInCat,
-        });
-        reorderedRowKeys.push(`${cat.name}::${rowName}`);
-        reorderedRowNames.push(rowName);
-      });
-    });
-
-    compositeRowKeys = reorderedRowKeys;
-    rowNames = reorderedRowNames;
-  } else {
-    // No row categories: create default metadata
-    rowMetadata = rowNames.map((name: string, idx: number) => ({
-      name,
-      category: '',
-      categoryIndex: 0,
-      indexInCategory: idx,
-    }));
-  }
-
-  const numSquaresInMatrix = rowNames.length * colNames.length;
+  const numSquaresInMatrix = rowNamesSet.size * colNamesSet.size;
   if (numSquaresInMatrix > 50000) {
-    return { rows: null, columns: null, colMetadata: [], colCategories: [], rowMetadata: [], rowCategories: [], data: 'too many inputs', legend: null };
+    return { rowNames: null, colNames: null, colCategories: [], rowCategories: [], data: 'too many inputs', legend: null };
   }
 
-  // Phase 1: Collect all values per cell using composite keys
-  const cellValues = new Map<string, number[]>();
+  const rowNames: any[] = Array.from(rowNamesSet);
+  const colNames: any[] = Array.from(colNamesSet);
+  const rowCategories: Category[] = Array.from(rowCategoriesMap.values());
+  const colCategories: Category[] = Array.from(colCategoriesMap.values());
 
-  frame.forEach((row) => {
-    const rowName = String(row[sourceKey]);
-    const colName = String(row[targetKey]);
-    const colCat = colGrouping && row[colCategoryKey] != null ? String(row[colCategoryKey]) : '';
-    const rowCat = rowGrouping && row[rowCategoryKey] != null ? String(row[rowCategoryKey]) : '';
-
-    const colKey = colGrouping ? `${colCat}::${colName}` : colName;
-    const rowKey = rowGrouping ? `${rowCat}::${rowName}` : rowName;
-
-    const r = compositeRowKeys.indexOf(rowKey);
-    const c = compositeColKeys.indexOf(colKey);
-    const v = row[valKey];
-
-    if (r > -1 && c > -1 && v != null) {
-      const cellKey = `${r}:${c}`;
-      if (!cellValues.has(cellKey)) {
-        cellValues.set(cellKey, []);
-      }
-      cellValues.get(cellKey)!.push(v);
-    }
-  });
-
-  // Phase 2: Aggregate values and build data matrix
+  // create data matrix
   let dataMatrix: any[][] = [];
   for (let i = 0; i < rowNames.length; i++) {
     dataMatrix.push(new Array(colNames.length).fill(-1));
   }
 
-  const aggMethod = options.aggregationMethod || 'sum';
-
-  cellValues.forEach((values, cellKey) => {
-    const [r, c] = cellKey.split(':').map(Number);
-    const v = values.length === 1 ? values[0] : aggregate(values, aggMethod);
-    dataMatrix[r][c] = {
-      row: rowNames[r],
-      col: colNames[c],
-      val: v,
-      color: colorMap(v),
-      display: valueField.display(v),
-    };
+  frame.forEach((row) => {
+    const rowName = row[sourceKey];
+    const colName = row[targetKey];
+    const r = rowNames.indexOf(rowName);
+    const c = colNames.indexOf(colName);
+    const v = row[valKey];
+    if (r > -1 && c > -1) {
+      dataMatrix[r][c] = {
+        row: rowName,
+        col: colName,
+        val: v,
+        color: colorMap(v),
+        display: valueField.display(v),
+      };
+    }
   });
 
   // parse data for legend
@@ -372,11 +234,9 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
   }
 
   let dataObject = {
-    rows: rowNames,
-    columns: colNames,
-    colMetadata: colMetadata,
+    rowNames: rowNames,
+    colNames: colNames,
     colCategories: colCategories,
-    rowMetadata: rowMetadata,
     rowCategories: rowCategories,
     data: dataMatrix,
     legend: legendData,

--- a/src/matrix.d.ts
+++ b/src/matrix.d.ts
@@ -6,8 +6,6 @@ export function matrix(
   height: number,
   options: any,
   legend: any,
-  colMetadata: any,
-  colCategories: any,
-  rowMetadata: any,
-  rowCategories: any
+  colCategories: Category[],
+  rowCategories: Category[],
 ): LegacyRef<SVGSVGElement> | undefined;

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -4,6 +4,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, useTheme2 } from '@grafana/ui';
 import sanitizeHtml from 'sanitize-html';
+import { Heading } from './types';
 
 /** Create the matrix diagram using d3.
  * @param {*} elem The parent svg element that will house this diagram
@@ -16,7 +17,7 @@ import sanitizeHtml from 'sanitize-html';
  * @param {GrafanaTheme} theme
  * @param {CSSReturnValue} styles
  */
-function createViz(elem, id, height, rowNames, colNames, matrix, options, theme, legend, styles, colMetadata, colCategories, rowMetadata, rowCategories) {
+function createViz(elem, id, height, rowNames, colNames, matrix, options, theme, legend, styles, colCategories, rowCategories) {
   const srcText = sanitizeHtml(options.sourceText),
     targetText = sanitizeHtml(options.targetText),
     valText = sanitizeHtml(options.valueText),
@@ -66,16 +67,16 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
     : 0;
 
   // Calculate column positions with gaps between colCategories
-  let columnPositions = [];
+  const columnPositions: Heading[] = [];
   let totalWidth = 0;
 
   if (options.enableColGrouping && colCategories && colCategories.length > 0) {
     // Calculate positions with category gaps
     colCategories.forEach((category, catIndex) => {
-      const numCols = category.columns.length;
+      const numCols = category.items.length;
       const groupWidth = numCols * cellSize;
 
-      category.columns.forEach((colName, indexInCat) => {
+      category.items.forEach((colName, indexInCat) => {
         columnPositions.push({
           name: colName,
           x: totalWidth + (indexInCat * cellSize),
@@ -113,15 +114,15 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
     : 0;
 
   // Calculate row positions with gaps between colCategories
-  let rowPositions = [];
+  const rowPositions: Heading[] = [];
   let totalHeight = 0;
 
   if (options.enableRowGrouping && rowCategories && rowCategories.length > 0) {
     rowCategories.forEach((category, catIndex) => {
-      const numRows = category.rows.length;
+      const numRows = category.items.length;
       const groupHeight = numRows * cellSize;
 
-      category.rows.forEach((rowName, indexInCat) => {
+      category.items.forEach((rowName, indexInCat) => {
         rowPositions.push({
           name: rowName,
           y: totalHeight + (indexInCat * cellSize),
@@ -267,8 +268,23 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
       .attr('transform', `translate(0, ${-colTxtOffset - colCategoryHeaderHeight})`);
 
     colCategories.forEach((category, catIndex) => {
-      const startPos = columnPositions[category.startIndex];
-      const endPos = columnPositions[category.endIndex];
+      // find first and last column heading for this category
+      let startPos = undefined;
+      let endPos = undefined;
+      for (let i = 0; i < columnPositions.length; i++) {
+        if (columnPositions[i].category === category.name) {
+          if (startPos === undefined) {
+            // first column heading for the category
+            startPos = columnPositions[i];
+            endPos = columnPositions[i];
+          } else {
+            endPos = columnPositions[i];
+          }
+        } else if (startPos !== undefined) {
+          // no more column headings for this category
+          break;
+        }
+      }
 
       if (startPos && endPos) {
         const groupX = startPos.x;
@@ -314,8 +330,23 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
       .attr('transform', `translate(${-rowTxtOffset - rowCategoryHeaderWidth}, 0)`);
 
     rowCategories.forEach((category, catIndex) => {
-      const startPos = rowPositions[category.startIndex];
-      const endPos = rowPositions[category.endIndex];
+      // find first and last row heading for this category
+      let startPos = undefined;
+      let endPos = undefined;
+      for (let i = 0; i < rowPositions.length; i++) {
+        if (rowPositions[i].category === category.name) {
+          if (startPos === undefined) {
+            // first row heading for the category
+            startPos = rowPositions[i];
+            endPos = rowPositions[i];
+          } else {
+            endPos = rowPositions[i];
+          }
+        } else if (startPos !== undefined) {
+          // no more row headings for this category
+          break;
+        }
+      }
 
       if (startPos && endPos) {
         const groupY = startPos.y;
@@ -670,11 +701,11 @@ const getStyles = (theme: GrafanaTheme2) => {
  * @param {number} height Height of panel
  * @return {*} A d3 callback
  */
-function matrix(rowNames, colNames, matrix, id, height, options, legend, colMetadata, colCategories, rowMetadata, rowCategories) {
+function matrix(rowNames, colNames, matrix, id, height, options, legend, colCategories, rowCategories) {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
   const ref = useD3((svg) => {
-    createViz(svg, id, height, rowNames, colNames, matrix, options, theme, legend, styles, colMetadata, colCategories, rowMetadata, rowCategories);
+    createViz(svg, id, height, rowNames, colNames, matrix, options, theme, legend, styles, colCategories, rowCategories);
   });
   return ref;
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import { FieldOverrideContext, getFieldDisplayName, PanelPlugin, FieldConfigProperty } from '@grafana/data';
+import { Field, FieldConfigProperty, FieldType, PanelPlugin } from '@grafana/data';
 // import { standardOptionsCompat } from 'grafana-plugin-support';
 import { MatrixOptions } from './types';
 import { EsnetMatrix } from './EsnetMatrix';
@@ -67,100 +67,41 @@ plugin.setPanelOptions((builder) => {
     category: RowOptions,
     showIf: staticBool(true),
   });
-  builder.addSelect({
+  builder.addFieldNamePicker({
     path: 'sourceField',
     name: 'Rows Field',
     description: 'Select the field that should be used for the rows',
     category: RowOptions,
     settings: {
-      allowCustomValue: false,
-      options: [],
-      getOptions: async (context: FieldOverrideContext) => {
-        const options = [];
-        if (context && context.data) {
-          for (const frame of context.data) {
-            for (const field of frame.fields) {
-              const name = getFieldDisplayName(field, frame, context.data);
-              const value = name;
-              options.push({ value, label: name });
-            }
-          }
-        }
-        return Promise.resolve(options);
-      },
+      filter: (field: Field) => field.type === FieldType.string,
     },
-    // defaultValue: options[0],
   });
-  builder.addSelect({
+  builder.addFieldNamePicker({
     path: 'targetField',
     name: 'Columns Field',
     description: 'Select the field to use for the columns',
     category: RowOptions,
     settings: {
-      allowCustomValue: false,
-      options: [],
-      getOptions: async (context: FieldOverrideContext) => {
-        const options = [];
-        if (context && context.data) {
-          for (const frame of context.data) {
-            for (const field of frame.fields) {
-              const name = getFieldDisplayName(field, frame, context.data);
-              const value = name;
-              options.push({ value, label: name });
-            }
-          }
-        }
-        return Promise.resolve(options);
-      },
+      filter: (field: Field) => field.type === FieldType.string,
     },
   });
-  builder.addSelect({
+  builder.addFieldNamePicker({
     path: 'valueField',
     name: 'Value Field',
     description: 'Select the numeric field used to color the matrix cells.',
     category: RowOptions,
     settings: {
-      allowCustomValue: false,
-      options: [],
-      getOptions: async (context: FieldOverrideContext) => {
-        const options = [];
-        if (context && context.data) {
-          for (const frame of context.data) {
-            for (const field of frame.fields) {
-              if (field.type === 'number') {
-                const name = getFieldDisplayName(field, frame, context.data);
-                const value = name;
-                options.push({ value, label: name });
-              }
-            }
-          }
-        }
-        return Promise.resolve(options);
-      },
+      filter: (field: Field) => field.type === FieldType.number,
     },
   });
-  builder.addSelect({
+  builder.addFieldNamePicker({
     path: 'colCategoryField',
     name: 'Column Category Field',
     description: 'Select the field to use for grouping columns into categories',
     category: RowOptions,
     showIf: colGroupingBool(true),
     settings: {
-      allowCustomValue: false,
-      options: [],
-      getOptions: async (context: FieldOverrideContext) => {
-        const options = [{ value: '', label: 'None' }];
-        if (context && context.data) {
-          for (const frame of context.data) {
-            for (const field of frame.fields) {
-              const name = getFieldDisplayName(field, frame, context.data);
-              const value = name;
-              options.push({ value, label: name });
-            }
-          }
-        }
-        return Promise.resolve(options);
-      },
+      filter: (field: Field) => field.type === FieldType.string,
     },
   });
   builder.addBooleanSwitch({
@@ -207,28 +148,14 @@ plugin.setPanelOptions((builder) => {
   });
 
   ////////------------ Row Grouping Options ----------------/////////////
-  builder.addSelect({
+  builder.addFieldNamePicker({
     path: 'rowCategoryField',
     name: 'Row Category Field',
     description: 'Select the field to use for grouping rows into categories',
     category: RowOptions,
     showIf: rowGroupingBool(true),
     settings: {
-      allowCustomValue: false,
-      options: [],
-      getOptions: async (context: FieldOverrideContext) => {
-        const options = [{ value: '', label: 'None' }];
-        if (context && context.data) {
-          for (const frame of context.data) {
-            for (const field of frame.fields) {
-              const name = getFieldDisplayName(field, frame, context.data);
-              const value = name;
-              options.push({ value, label: name });
-            }
-          }
-        }
-        return Promise.resolve(options);
-      },
+      filter: (field: Field) => field.type === FieldType.string,
     },
   });
   builder.addNumberInput({

--- a/src/module.ts
+++ b/src/module.ts
@@ -45,8 +45,31 @@ plugin.useFieldConfig({
   ]
 });
 
+plugin.setMigrationHandler((panel) => {
+  if (panel.options.sortType === undefined) {
+    panel.options.sortType = 'natural-asc'
+  }
+
+  return panel.options;
+});
+
 plugin.setPanelOptions((builder) => {
   /////////--------- Row and Column options ---------////////////////
+  builder.addSelect({
+    path: 'sortType',
+    name: 'Sort Type',
+    description: 'Sorting to apply to row/column headings',
+    category: RowOptions,
+    defaultValue: 'natural-asc',
+    settings: {
+      allowCustomValue: false,
+      options: [
+        { value: 'none', label: 'None' },
+        { value: 'natural-asc', label: 'Natural ascending' },
+        { value: 'natural-desc', label: 'Natural descending' },
+      ],
+    },
+  });
   builder.addBooleanSwitch({
     path: 'inputList',
     name: 'Use Static Row/Column Headings',

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,20 +49,20 @@ plugin.setPanelOptions((builder) => {
   /////////--------- Row and Column options ---------////////////////
   builder.addBooleanSwitch({
     path: 'inputList',
-    name: 'Use Static Row/Column Lists',
+    name: 'Use Static Row/Column Headings',
     category: RowOptions,
     defaultValue: false,
   });
   builder.addTextInput({
     path: 'staticRows',
-    name: 'Row Array',
+    name: 'Row Headings',
     description: 'Terms to use as matrix rows (comma separated)',
     category: RowOptions,
     showIf: staticBool(true),
   });
   builder.addTextInput({
     path: 'staticColumns',
-    name: 'Column Array',
+    name: 'Column Headings',
     description: 'Terms to use as matrix columns (comma separated)',
     category: RowOptions,
     showIf: staticBool(true),
@@ -188,24 +188,6 @@ plugin.setPanelOptions((builder) => {
   });
 
   ////////------------ General Matrix Options ----------------/////////////
-  builder.addSelect({
-    path: 'aggregationMethod',
-    name: 'Aggregation Method',
-    description: 'How to aggregate values when multiple data points map to the same cell',
-    category: OptionsCategory,
-    showIf: (config: MatrixOptions) => config.enableColGrouping || config.enableRowGrouping,
-    defaultValue: 'sum',
-    settings: {
-      allowCustomValue: false,
-      options: [
-        { value: 'sum', label: 'Sum' },
-        { value: 'avg', label: 'Average' },
-        { value: 'min', label: 'Min' },
-        { value: 'max', label: 'Max' },
-        { value: 'last', label: 'Last' },
-      ],
-    },
-  });
   builder.addBooleanSwitch({
     path: 'showLegend',
     name: 'Show Legend',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export interface MatrixOptions {
+  sortType: string;
   sourceField: string;
   targetField: string;
   valueField: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,8 +28,20 @@ export interface MatrixOptions {
   inputList: boolean;
   staticRows: string[];
   staticColumns: string[];
-  aggregationMethod: string;
   showLegend: boolean;
   legendType: string;
   thresholds: any[];
 }
+
+export type Category = {
+  name: any;
+  items: any[];
+};
+
+export type Heading = {
+  name: string;
+  x: number;
+  width: number;
+  category: string;
+  categoryIndex: number;
+};


### PR DESCRIPTION
This PR fixes a few different bugs with field selection for row names, column names and values.

Currently if a field is selected to use as the row/column names, but the field doesn't actually exist in the dataframe, this exception will occur:
<img width="512" height="94" alt="Screenshot_20250917_183146" src="https://github.com/user-attachments/assets/f545289b-e3b7-49f5-af46-45487e79659b" />

If the static row/column name option is enabled but no row or column names are provided, this exception will occur:
<img width="512" height="94" alt="Screenshot_20250917_183108" src="https://github.com/user-attachments/assets/aae12fea-3469-4e1c-a432-eb141198dccf" />

I have also moved the row/column/value options to use the grafana-ui native FieldNamePicker, and updated the field selection logic in dataParser.ts to add support for renamed data fields (by changing the data source display name or using a transformation). 

fixes #17
fixes #8 
fixes #10