### PR TITLE
feat: Update the logic to group data by rows and columns and aggregate data

### DIFF
--- a/src/dataParser.ts
+++ b/src/dataParser.ts
@@ -1,7 +1,5 @@
 import { DataFrameView } from '@grafana/data';
 
-// import { legend } from 'matrixLegend';
-
 /**
  * this function creates an adjacency matrix to be consumed by the chord
  * function returns the matrix + forward and reverse lookup Maps to go from
@@ -64,68 +62,104 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
     }
   }
 
-  // Make Row and Column Lists
-  let rows: any[] = [];
-  let columns: any[] = [];
-  // let uniqueVals: any[] = [];
+  // Aggregation helper
+  const colGrouping = !!(colCategoryKey && options.enableColGrouping);
+  const rowGrouping = !!(rowCategoryKey && options.enableRowGrouping);
+
+  // Aggregation function to combine multiple values for the same cell based on user-selected method
+  // By default: aggregate is set to "sum"
+  // Falls back to "last" for non-numeric values (strings, etc.)
+  function aggregate(values: any[], method: string): any {
+    if (values.length === 0) {
+      return null;
+    }
+    // For non-numeric values, only "last" is meaningful
+    if (typeof values[0] !== 'number') {
+      return values[values.length - 1];
+    }
+    switch (method) {
+      case 'sum': return values.reduce((a: number, b: number) => a + b, 0);
+      case 'avg': return values.reduce((a: number, b: number) => a + b, 0) / values.length;
+      case 'min': return Math.min(...values);
+      case 'max': return Math.max(...values);
+      case 'last': return values[values.length - 1];
+      default: return values.reduce((a: number, b: number) => a + b, 0);
+    }
+  }
+
+  // Build composite keys from data
+  // When grouping is enabled, use "category::name" as the key to allow
+  // the same name in multiple categories. Otherwise, just use the name.
+  let compositeColKeys: string[] = [];
+  let compositeRowKeys: string[] = [];
 
   // IF static list toggle is set, use input list
   if (options.inputList) {
-    rows = options.staticRows.split(',');
-    columns = options.staticColumns.split(',');
+    const staticRows = options.staticRows.split(',');
+    const staticCols = options.staticColumns.split(',');
+    compositeRowKeys = Array.from(new Set(staticRows));
+    compositeColKeys = Array.from(new Set(staticCols));
   } else {
-    // ELSE  Make new arrays from unique set of row and column axis labels
-    // find all axis labels
+    // Build unique composite keys from data
+    const colKeySet = new Set<string>();
+    const rowKeySet = new Set<string>();
+
     frame.forEach((row) => {
-      rows.push(String(row[sourceKey]));
-      columns.push(String(row[targetKey]));
+      const rowName = String(row[sourceKey]);
+      const colName = String(row[targetKey]);
+      const colCat = colGrouping && row[colCategoryKey] != null ? String(row[colCategoryKey]) : '';
+      const rowCat = rowGrouping && row[rowCategoryKey] != null ? String(row[rowCategoryKey]) : '';
+
+      const colKey = colGrouping ? `${colCat}::${colName}` : colName;
+      const rowKey = rowGrouping ? `${rowCat}::${rowName}` : rowName;
+
+      colKeySet.add(colKey);
+      rowKeySet.add(rowKey);
     });
+
+    compositeColKeys = Array.from(colKeySet).sort();
+    compositeRowKeys = Array.from(rowKeySet).sort();
   }
-  // get unique set
-  let rowNames = Array.from(new Set(rows)).sort();
-  let colNames = Array.from(new Set(columns)).sort();
+
+  // Extract display names from composite keys
+  let colNames = compositeColKeys.map((k) => colGrouping && k.includes('::') ? k.split('::').slice(1).join('::') : k);
+  let rowNames = compositeRowKeys.map((k) => rowGrouping && k.includes('::') ? k.split('::').slice(1).join('::') : k);
 
   // Build column metadata and category groupings
   let colMetadata: any[] = [];
   let colCategories: any[] = [];
 
-  if (colCategoryKey && options.enableColGrouping) {
-    // Build column -> category mapping from data
-    const colToCategoryMap = new Map<string, string>();
-    frame.forEach((row) => {
-      const col = String(row[targetKey]);
-      const cat = row[colCategoryKey] != null ? String(row[colCategoryKey]) : 'Uncategorized';
-      if (!colToCategoryMap.has(col)) {
-        colToCategoryMap.set(col, cat);
-      }
-    });
+  if (colGrouping) {
+    // Group columns by category using composite keys
+    const categoryToColumns = new Map<string, Array<{ name: string; key: string }>>();
 
-    // Group columns by category
-    const categoryToColumns = new Map<string, string[]>();
-    colNames.forEach((col) => {
-      const cat = colToCategoryMap.get(col) || 'Uncategorized';
+    compositeColKeys.forEach((key) => {
+      const [cat, ...nameParts] = key.split('::');
+      const name = nameParts.join('::');
       if (!categoryToColumns.has(cat)) {
         categoryToColumns.set(cat, []);
       }
-      categoryToColumns.get(cat)!.push(col);
+      categoryToColumns.get(cat)!.push({ name, key });
     });
 
     // Build CategoryGroup array (sorted by category name)
     const sortedCategories = Array.from(categoryToColumns.keys()).sort();
     let globalIndex = 0;
 
-    sortedCategories.forEach((catName, catIndex) => {
+    sortedCategories.forEach((catName) => {
       const columnsInCat = categoryToColumns.get(catName)!;
       colCategories.push({
         name: catName,
-        columns: columnsInCat,
+        columns: columnsInCat.map((c) => c.name),
         startIndex: globalIndex,
         endIndex: globalIndex + columnsInCat.length - 1,
       });
       globalIndex += columnsInCat.length;
     });
 
-    // Build ColumnInfo array
+    // Build ColumnInfo array and re-order colNames/compositeColKeys to match grouped order
+    const reorderedColKeys: string[] = [];
+    const reorderedColNames: string[] = [];
     colCategories.forEach((cat: any, catIndex: number) => {
       cat.columns.forEach((colName: string, indexInCat: number) => {
         colMetadata.push({
@@ -134,11 +168,13 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
           categoryIndex: catIndex,
           indexInCategory: indexInCat,
         });
+        reorderedColKeys.push(`${cat.name}::${colName}`);
+        reorderedColNames.push(colName);
       });
     });
 
-    // Re-order colNames to match grouped order
-    colNames = colMetadata.map((cm: any) => cm.name);
+    compositeColKeys = reorderedColKeys;
+    colNames = reorderedColNames;
   } else {
     // No categories: create default metadata
     colMetadata = colNames.map((name: string, idx: number) => ({
@@ -153,25 +189,17 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
   let rowMetadata: any[] = [];
   let rowCategories: any[] = [];
 
-  if (rowCategoryKey && options.enableRowGrouping) {
-    // Build row -> category mapping from data
-    const rowToCategoryMap = new Map<string, string>();
-    frame.forEach((row) => {
-      const rowName = String(row[sourceKey]);
-      const cat = row[rowCategoryKey] != null ? String(row[rowCategoryKey]) : 'Uncategorized';
-      if (!rowToCategoryMap.has(rowName)) {
-        rowToCategoryMap.set(rowName, cat);
-      }
-    });
+  if (rowGrouping) {
+    // Group rows by category using composite keys
+    const categoryToRows = new Map<string, Array<{ name: string; key: string }>>();
 
-    // Group rows by category
-    const categoryToRows = new Map<string, string[]>();
-    rowNames.forEach((rowName) => {
-      const cat = rowToCategoryMap.get(rowName) || 'Uncategorized';
+    compositeRowKeys.forEach((key) => {
+      const [cat, ...nameParts] = key.split('::');
+      const name = nameParts.join('::');
       if (!categoryToRows.has(cat)) {
         categoryToRows.set(cat, []);
       }
-      categoryToRows.get(cat)!.push(rowName);
+      categoryToRows.get(cat)!.push({ name, key });
     });
 
     // Build RowCategoryGroup array (sorted by category name)
@@ -182,14 +210,16 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
       const rowsInCat = categoryToRows.get(catName)!;
       rowCategories.push({
         name: catName,
-        rows: rowsInCat,
+        rows: rowsInCat.map((r) => r.name),
         startIndex: globalRowIndex,
         endIndex: globalRowIndex + rowsInCat.length - 1,
       });
       globalRowIndex += rowsInCat.length;
     });
 
-    // Build RowInfo array
+    // Build RowInfo array and re-order rowNames/compositeRowKeys to match grouped order
+    const reorderedRowKeys: string[] = [];
+    const reorderedRowNames: string[] = [];
     rowCategories.forEach((cat: any, catIndex: number) => {
       cat.rows.forEach((rowName: string, indexInCat: number) => {
         rowMetadata.push({
@@ -198,11 +228,13 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
           categoryIndex: catIndex,
           indexInCategory: indexInCat,
         });
+        reorderedRowKeys.push(`${cat.name}::${rowName}`);
+        reorderedRowNames.push(rowName);
       });
     });
 
-    // Re-order rowNames to match grouped order
-    rowNames = rowMetadata.map((rm: any) => rm.name);
+    compositeRowKeys = reorderedRowKeys;
+    rowNames = reorderedRowNames;
   } else {
     // No row categories: create default metadata
     rowMetadata = rowNames.map((name: string, idx: number) => ({
@@ -218,24 +250,49 @@ export function parseData(data: { series: any[] }, options: any, theme: any) {
     return { rows: null, columns: null, colMetadata: [], colCategories: [], rowMetadata: [], rowCategories: [], data: 'too many inputs', legend: null };
   }
 
-  // create data matrix
+  // Phase 1: Collect all values per cell using composite keys
+  const cellValues = new Map<string, number[]>();
+
+  frame.forEach((row) => {
+    const rowName = String(row[sourceKey]);
+    const colName = String(row[targetKey]);
+    const colCat = colGrouping && row[colCategoryKey] != null ? String(row[colCategoryKey]) : '';
+    const rowCat = rowGrouping && row[rowCategoryKey] != null ? String(row[rowCategoryKey]) : '';
+
+    const colKey = colGrouping ? `${colCat}::${colName}` : colName;
+    const rowKey = rowGrouping ? `${rowCat}::${rowName}` : rowName;
+
+    const r = compositeRowKeys.indexOf(rowKey);
+    const c = compositeColKeys.indexOf(colKey);
+    const v = row[valKey];
+
+    if (r > -1 && c > -1 && v != null) {
+      const cellKey = `${r}:${c}`;
+      if (!cellValues.has(cellKey)) {
+        cellValues.set(cellKey, []);
+      }
+      cellValues.get(cellKey)!.push(v);
+    }
+  });
+
+  // Phase 2: Aggregate values and build data matrix
   let dataMatrix: any[][] = [];
   for (let i = 0; i < rowNames.length; i++) {
     dataMatrix.push(new Array(colNames.length).fill(-1));
   }
-  frame.forEach((row) => {
-    let r = rowNames.indexOf(String(row[sourceKey]));
-    let c = colNames.indexOf(String(row[targetKey]));
-    let v = row[valKey];
-    if (r > -1 && c > -1 && dataMatrix[r][c] === -1) {
-      dataMatrix[r][c] = {
-        row: row[sourceKey],
-        col: row[targetKey],
-        val: v,
-        color: colorMap(v),
-        display: valueField[0].display(v),
-      };
-    }
+
+  const aggMethod = options.aggregationMethod || 'sum';
+
+  cellValues.forEach((values, cellKey) => {
+    const [r, c] = cellKey.split(':').map(Number);
+    const v = values.length === 1 ? values[0] : aggregate(values, aggMethod);
+    dataMatrix[r][c] = {
+      row: rowNames[r],
+      col: colNames[c],
+      val: v,
+      color: colorMap(v),
+      display: valueField[0].display(v),
+    };
   });
 
   // parse data for legend

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -180,12 +180,10 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
     .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
   // Build X scales and axis:
-  // Create custom scale function that maps column names to x positions
-  var x = function(colName) {
-    const pos = columnPositions.find(cp => cp.name === colName);
-    return pos ? pos.x : 0;
+  // Index-based scale to support duplicate column names across categories
+  var x = function(colIndex) {
+    return columnPositions[colIndex] ? columnPositions[colIndex].x : 0;
   };
-  // Add bandwidth method for compatibility
   x.bandwidth = function() {
     return cellSize * (1 - cellPadding);
   };
@@ -223,9 +221,9 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   });
 
   // Build Y scales and axis:
-  var y = function(rowName) {
-    const pos = rowPositions.find(rp => rp.name === rowName);
-    return pos ? pos.y : 0;
+  // Index-based scale to support duplicate row names across categories
+  var y = function(rowIndex) {
+    return rowPositions[rowIndex] ? rowPositions[rowIndex].y : 0;
   };
   y.bandwidth = function() {
     return cellSize * (1 - cellPadding);
@@ -271,8 +269,8 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
       .attr('transform', `translate(0, ${-colTxtOffset - colCategoryHeaderHeight})`);
 
     colCategories.forEach((category, catIndex) => {
-      const startPos = columnPositions.find(cp => cp.name === category.columns[0]);
-      const endPos = columnPositions.find(cp => cp.name === category.columns[category.columns.length - 1]);
+      const startPos = columnPositions[category.startIndex];
+      const endPos = columnPositions[category.endIndex];
 
       if (startPos && endPos) {
         const groupX = startPos.x;
@@ -315,8 +313,8 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
       .attr('transform', `translate(${-rowTxtOffset - rowCategoryHeaderWidth}, 0)`);
 
     rowCategories.forEach((category, catIndex) => {
-      const startPos = rowPositions.find(rp => rp.name === category.rows[0]);
-      const endPos = rowPositions.find(rp => rp.name === category.rows[category.rows.length - 1]);
+      const startPos = rowPositions[category.startIndex];
+      const endPos = rowPositions[category.endIndex];
 
       if (startPos && endPos) {
         const groupY = startPos.y;
@@ -392,11 +390,11 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
     .append('rect')
     .attr('id', `rect-${id}`)
     .attr('x', function (d, i, j) {
-      return x(colNames[i]);
+      return x(i);
     })
     .attr('y', function (d, i, j) {
       var outer_counter = outer.get(this);
-      return y(rowNames[outer_counter]);
+      return y(outer_counter);
     })
     .attr('width', x.bandwidth())
     .attr('height', y.bandwidth())

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -322,9 +322,9 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
 
         // Horizontal labels
         rowCategoryHeaderGroup.append('text')
-          .attr('x', rowCategoryHeaderWidth / 2)
+          .attr('x', rowCategoryHeaderWidth)
           .attr('y', groupY + cellSize / 2)
-          .attr('text-anchor', 'middle')
+          .attr('text-anchor', 'end')
           .attr('dominant-baseline', 'middle')
           .attr('font-size', (txtSize * 1.2) + 'em')
           .attr('font-weight', 'bold')

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -53,12 +53,11 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   const maxColTxtLength = longestColName.length < txtLength ? longestColName.length : txtLength + 3;
   const maxRowTxtLength = longestRowName.length < txtLength ? longestRowName.length : txtLength + 3;
 
-  // the user settable value cellsize controls the size of the svg.
-  // var size = names.length * cellSize;
-
   // Calculate the margins needed
-  var colTxtOffset = maxColTxtLength * txtSize * 5 + 25;
-  var rowTxtOffset = maxRowTxtLength * txtSize * 5 + 25;
+  var colTxtOffset = maxColTxtLength * txtSize *                                                
+    (options.enableColGrouping && colCategories && colCategories.length > 0 ? 8 : 5) + 25;
+  var rowTxtOffset = maxRowTxtLength * txtSize *
+    (options.enableRowGrouping && rowCategories && rowCategories.length > 0 ? 8 : 5) + 25;
 
   // Category header configuration
   const colCategoryHeaderHeight = options.enableColGrouping && colCategories && colCategories.length > 0
@@ -276,7 +275,8 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
         const groupX = startPos.x;
         const groupWidth = (endPos.x + cellSize) - startPos.x;
 
-        // Category label rotated vertically (like column labels)
+        // Category label rotated vertically; truncated to fit colCategoryHeaderHeight.
+        const colGroupLabelMaxChars = Math.max(3, Math.floor((colCategoryHeaderHeight - 12) / (txtSize * 1.2 * 8)));
         categoryHeaderGroup.append('text')
           .attr('transform', `translate(${groupX + cellSize / 2}, ${colCategoryHeaderHeight - 12})rotate(-90)`)
           .attr('text-anchor', 'start')
@@ -285,6 +285,7 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
           .attr('fill', theme.colors.text.primary)
           .style('font-family', theme.typography.fontFamily)
           .text(category.name)
+          .call(truncateLabel, colGroupLabelMaxChars)
           .on('mouseover', function (event, d) {
             tooltip
               .html(sanitizeHtml(category.name))
@@ -320,9 +321,11 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
         const groupY = startPos.y;
         const groupHeight = (endPos.y + cellSize) - startPos.y;
 
-        // Horizontal labels
+        // Group label: right-aligned so text grows leftward into rowCategoryHeaderWidth.
+        // Truncated when wider than the allocated area; tooltip shows full name.
+        const groupLabelMaxChars = Math.max(3, Math.floor((rowCategoryHeaderWidth - 10) / (txtSize * 1.2 * 8)));
         rowCategoryHeaderGroup.append('text')
-          .attr('x', rowCategoryHeaderWidth)
+          .attr('x', rowCategoryHeaderWidth - 5)
           .attr('y', groupY + cellSize / 2)
           .attr('text-anchor', 'end')
           .attr('dominant-baseline', 'middle')
@@ -331,6 +334,7 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
           .attr('fill', theme.colors.text.primary)
           .style('font-family', theme.typography.fontFamily)
           .text(category.name)
+          .call(truncateLabel, groupLabelMaxChars)
           .on('mouseover', function (event, d) {
             tooltip
               .html(sanitizeHtml(category.name))

--- a/src/module.ts
+++ b/src/module.ts
@@ -127,16 +127,17 @@ plugin.setPanelOptions((builder) => {
         if (context && context.data) {
           for (const frame of context.data) {
             for (const field of frame.fields) {
-              const name = getFieldDisplayName(field, frame, context.data);
-              const value = name;
-              options.push({ value, label: name });
+              if (field.type === 'number') {
+                const name = getFieldDisplayName(field, frame, context.data);
+                const value = name;
+                options.push({ value, label: name });
+              }
             }
           }
         }
         return Promise.resolve(options);
       },
     },
-    // defaultValue: options[2],
   });
   builder.addSelect({
     path: 'colCategoryField',
@@ -260,6 +261,24 @@ plugin.setPanelOptions((builder) => {
   });
 
   ////////------------ General Matrix Options ----------------/////////////
+  builder.addSelect({
+    path: 'aggregationMethod',
+    name: 'Aggregation Method',
+    description: 'How to aggregate values when multiple data points map to the same cell',
+    category: OptionsCategory,
+    showIf: (config: MatrixOptions) => config.enableColGrouping || config.enableRowGrouping,
+    defaultValue: 'sum',
+    settings: {
+      allowCustomValue: false,
+      options: [
+        { value: 'sum', label: 'Sum' },
+        { value: 'avg', label: 'Average' },
+        { value: 'min', label: 'Min' },
+        { value: 'max', label: 'Max' },
+        { value: 'last', label: 'Last' },
+      ],
+    },
+  });
   builder.addBooleanSwitch({
     path: 'showLegend',
     name: 'Show Legend',

--- a/src/module.ts
+++ b/src/module.ts
@@ -179,8 +179,8 @@ plugin.setPanelOptions((builder) => {
   });
   builder.addNumberInput({
     path: 'colCategoryHeaderHeight',
-    name: 'Category Header Height',
-    description: 'Height in pixels for category header labels',
+    name: 'Column Groups Header Height',
+    description: 'Space in pixels above the matrix reserved for column group labels',
     category: OptionsCategory,
     showIf: colGroupingBool(true),
     settings: {
@@ -234,7 +234,7 @@ plugin.setPanelOptions((builder) => {
   builder.addNumberInput({
     path: 'rowCategoryHeaderWidth',
     name: 'Row Category Header Width',
-    description: 'Width in pixels for row category header labels',
+    description: 'Space in pixels to the left reserved for row group labels',
     category: OptionsCategory,
     showIf: rowGroupingBool(true),
     settings: {
@@ -317,7 +317,7 @@ plugin.setPanelOptions((builder) => {
 
   builder.addTextInput({
     path: 'valueText',
-    name: 'value Text',
+    name: 'Value Text',
     description: 'The text to be displayed in the tooltip.',
     category: OptionsCategory,
     defaultValue: 'Value',
@@ -355,7 +355,7 @@ plugin.setPanelOptions((builder) => {
   builder.addNumberInput({
     path: 'txtLength',
     name: 'Text Length',
-    description: 'adjust amount of space used for labels',
+    description: 'Maximum number of characters to display before truncating labels',
     category: OptionsCategory,
     settings: {
       placeholder: 'Auto',

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface MatrixOptions {
   inputList: boolean;
   staticRows: string[];
   staticColumns: string[];
+  aggregationMethod: string;
   showLegend: boolean;
   legendType: string;
   thresholds: any[];


### PR DESCRIPTION
This PR adds the ability to group data by rows and columns and aggregate data if multiple row / col pairs fit the same group. One can aggregate based on SUM, AVERAGE, MIN, MAX, LAST

**Sample data**

```
Row,Column,Value,GroupCategory,RowCategory
A,3,15,Science,Group1
A,3,22,Science,Group2
A,3,25,Maths,Group2
```

**Both row and column grouping**

<img width="169" height="185" alt="Screenshot 2026-04-23 at 7 08 13 PM" src="https://github.com/user-attachments/assets/c5ff04aa-7929-470b-a49f-d5c150e3c936" />

**Only column grouping**

- Aggregation Method: SUM

<img width="166" height="234" alt="Screenshot 2026-04-23 at 7 08 46 PM" src="https://github.com/user-attachments/assets/0f8ec22f-cdce-4449-a542-7d5ab6bdd92a" />

- Aggregation Method: AVERAGE

<img width="174" height="226" alt="Screenshot 2026-04-23 at 7 09 03 PM" src="https://github.com/user-attachments/assets/ada51251-e899-49b3-964f-8139db46b664" />

**Only row grouping**

- Aggregation Method: AVERAGE

<img width="237" height="156" alt="Screenshot 2026-04-23 at 7 10 34 PM" src="https://github.com/user-attachments/assets/30f589c7-4d90-4b2f-8f32-b2d16f5fcdbe" />

