### PR TITLE
Set fixed font-size on parent so relative font-size on axis labels works

### DIFF
--- a/src/matrix.js
+++ b/src/matrix.js
@@ -188,7 +188,7 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   };
 
   // Create axis manually with proper styling
-  var xAxisGroup = svg.append('g').attr('class', 'x-axis');
+  var xAxisGroup = svg.append('g').attr('class', 'x-axis').attr('font-size', '10');
   columnPositions.forEach(pos => {
     const label = xAxisGroup.append('text')
       .attr('transform', `translate(${pos.x + cellSize / 2},-12)rotate(-90)`)
@@ -229,7 +229,7 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   };
 
   // Create Y-axis manually with proper styling
-  var yAxisGroup = svg.append('g').attr('class', 'y-axis');
+  var yAxisGroup = svg.append('g').attr('class', 'y-axis').attr('font-size', '10');
   rowPositions.forEach(pos => {
     const label = yAxisGroup.append('text')
       .attr('x', -10)

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -54,10 +54,8 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   const maxRowTxtLength = longestRowName.length < txtLength ? longestRowName.length : txtLength + 3;
 
   // Calculate the margins needed
-  var colTxtOffset = maxColTxtLength * txtSize *                                                
-    (options.enableColGrouping && colCategories && colCategories.length > 0 ? 8 : 5) + 25;
-  var rowTxtOffset = maxRowTxtLength * txtSize *
-    (options.enableRowGrouping && rowCategories && rowCategories.length > 0 ? 8 : 5) + 25;
+  var colTxtOffset = maxColTxtLength * txtSize * 5 + 25;
+  var rowTxtOffset = maxRowTxtLength * txtSize * 5 + 25;
 
   // Category header configuration
   const colCategoryHeaderHeight = options.enableColGrouping && colCategories && colCategories.length > 0
@@ -265,6 +263,7 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   if (options.enableColGrouping && colCategories && colCategories.length > 0) {
     const categoryHeaderGroup = svg.append('g')
       .attr('class', `category-headers-${id}`)
+      .attr('font-size', '10')
       .attr('transform', `translate(0, ${-colTxtOffset - colCategoryHeaderHeight})`);
 
     colCategories.forEach((category, catIndex) => {
@@ -311,6 +310,7 @@ function createViz(elem, id, height, rowNames, colNames, matrix, options, theme,
   if (options.enableRowGrouping && rowCategories && rowCategories.length > 0) {
     const rowCategoryHeaderGroup = svg.append('g')
       .attr('class', `row-category-headers-${id}`)
+      .attr('font-size', '10')
       .attr('transform', `translate(${-rowTxtOffset - rowCategoryHeaderWidth}, 0)`);
 
     rowCategories.forEach((category, catIndex) => {


### PR DESCRIPTION
Text size for the matrix panel is a little unintuitive, the `txtSize` variable is calculated as the ratio between the "text size" option and the value 10:

```js
txtSize = options.txtSize / 10, //convert this val to EM scaling 90 = .9em 100 = 1em ... etc
```

i.e for 10px `txtSize == 1`, for 12px `txtSize == 1.2`, etc. Ignore the comment here as this is no longer correct (see f5ac37901d23dec01fb1102fd89b9cc3d4459e7b for when this changed).

Before #26, the matrix panel used [d3-axis](https://d3js.org/d3-axis) for creating the axis elements which created a DOM structure where the axis labels were nested inside a `<g>` element with a fixed font-size of 10px:

```html
<svg id="svg-1"> 
  <g fill="none" font-size="10" text-anchor="middle">
    <text text-anchor="start" font-size="1.2em">host-01.example.org</text>
    ...
  </g>
</svg>
```

This meant that if the "text size" option was configured as 12px, `txtSize` got set to 1.2 and the `<text>` element ended up with a font-size of 1.2em (i.e 1.2 times larger than the parent element). However the DOM structure for v2.0.2 now looks like:

```html
<svg id="svg-1">
  <g class="x-axis">
      <text text-anchor="start" font-size="1.2em">host-01.example.org</text>
  ...
  </g>
</svg>
```

The immediate parent element no longer has a fixed font-size, so the browser will keep looking up the DOM hierarchy until it finds an element with a font-size. In this case `<body>` has a font-size of 14px, so the axis label text size will be scaled based on this value, which means the calculated padding/margins are incorrect and the label renders outside the panel div and is partially not visible.

This patch includes the simplest fix for this issue, which is restoring the old behaviour of v2.0.1 and below by adding the fixed font-size of 10px back to the axis container element. I guess another fix could be changing how the font size is configured and used when generating the matrix panel.

Note: I haven't worked out how the new row grouping feature works, so I have not tested this patch against that feature, it is entirely possible this code needs updating as well:

```js
        // Category label rotated vertically; truncated to fit colCategoryHeaderHeight.
        const colGroupLabelMaxChars = Math.max(3, Math.floor((colCategoryHeaderHeight - 12) / (txtSize * 1.2 * 8)));
        categoryHeaderGroup.append('text')
          .attr('transform', `translate(${groupX + cellSize / 2}, ${colCategoryHeaderHeight - 12})rotate(-90)`)
          .attr('text-anchor', 'start')
          .attr('font-size', (txtSize * 1.2) + 'em')
...
        // Group label: right-aligned so text grows leftward into rowCategoryHeaderWidth.
        // Truncated when wider than the allocated area; tooltip shows full name.
        const groupLabelMaxChars = Math.max(3, Math.floor((rowCategoryHeaderWidth - 10) / (txtSize * 1.2 * 8)));
        rowCategoryHeaderGroup.append('text')
          .attr('x', rowCategoryHeaderWidth - 5)
          .attr('y', groupY + cellSize / 2)
          .attr('text-anchor', 'end')
          .attr('dominant-baseline', 'middle')
          .attr('font-size', (txtSize * 1.2) + 'em')
```

Fixes #30

/cc @KatrinaTurner 