### PR TITLE
Migrate from deprecated CustomScrollbar to ScrollContainer

### DIFF
--- a/src/EsnetMatrix.tsx
+++ b/src/EsnetMatrix.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FieldConfigSource, PanelProps } from '@grafana/data';
 import { MatrixOptions } from 'types';
 import { parseData } from 'dataParser';
-import { useTheme2, CustomScrollbar } from '@grafana/ui';
+import { useTheme2, ScrollContainer } from '@grafana/ui';
 
 import * as Matrix from './matrix.js';
 
@@ -47,8 +47,8 @@ export const EsnetMatrix: React.FC<Props> = ({ options, data, width, height, id 
   const thisPanelClass = `matrix-panel-${id}`;
 
   return (
-    <CustomScrollbar autoHeightMin="100%">
+    <ScrollContainer minHeight="100%">
       <div ref={ref} id={thisPanelClass}></div>
-    </CustomScrollbar>
+    </ScrollContainer>
   );
 };


### PR DESCRIPTION
Fixes this lint warning:

```
Warning:   46:6   warning  `CustomScrollbar` is deprecated. Use `ScrollContainer` from `@grafana/ui` instead. It uses native scrollbars and has a simpler API                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             @typescript-eslint/no-deprecated
```