### PR TITLE
Replace custom link implementation with native grafana data links

### DIFF
--- a/provisioning/dashboards/dashboard.json
+++ b/provisioning/dashboards/dashboard.json
@@ -31,6 +31,12 @@
           "color": {
             "mode": "continuous-GrYlRd"
           },
+          "links": [
+            {
+              "title": "Show details",
+              "url": "http://localhost:3000/d/a538aeff-5a8a-42a5-901c-938d896fdd6f/provisioned-matrix-dashboard?var-Source=${__data.fields.Source}﻿&var-Destination=${__data.fields.Destination}"
+            }
+          ],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",

--- a/src/dataParser.ts
+++ b/src/dataParser.ts
@@ -218,19 +218,27 @@ export function parseData(data: PanelData, options: MatrixOptions, theme: Grafan
     dataMatrix.push(new Array(colNames.length).fill(-1));
   }
 
-  frame.forEach((row) => {
+  frame.forEach((row, idx) => {
     const rowName = row[sourceKey];
     const colName = row[targetKey];
     const r = rowNames.indexOf(rowName);
     const c = colNames.indexOf(colName);
     const v = row[valKey];
     if (r > -1 && c > -1) {
+      let url = undefined;
+      if ((valueField.config.links?.length ?? 0) > 0 && valueField.getLinks) {
+        const links = valueField.getLinks({ valueRowIndex: idx });
+        if (links.length >= 1) {
+          url = links[0];
+        }
+      }
       dataMatrix[r][c] = {
         row: rowName,
         col: colName,
         val: v,
         color: colorMap(v),
         display: valueField.display(v),
+        url: url,
       };
     }
   });

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -28,13 +28,7 @@ function createViz(elem, id, rowNames, colNames, matrix, options, theme, legend,
     cellPadding = options.cellPadding / 100, // convert the cellPadding integer to a float that can be used by d3
     txtLength = options.txtLength,
     txtSize = options.txtSize / 10, //convert this val to EM scaling 90 = .9em 100 = 1em ... etc
-    linkURL = options.url,
-    urlVar1 = options.urlVar1,
-    urlVar2 = options.urlVar2,
     defaultColor = theme.visualization.getColorByName(options.defaultColor);
-
-  // urlOther = options.urlOther,
-  // urlOtherText = options.urlOtherText;
 
   // do a bit of work to setup the visual layout of the wiget --------
   if (elem === null) {
@@ -414,15 +408,13 @@ function createViz(elem, id, rowNames, colNames, matrix, options, theme, legend,
     .enter()
     .append('a')
     .attr('xlink:href', (d) => {
-      if (linkURL) {
-        let thisURL = linkURL;
-        if (urlVar1) {
-          thisURL = thisURL.concat(`&var-${urlVar1}=${d.row}`);
-        }
-        if (urlVar2) {
-          thisURL = thisURL.concat(`&var-${urlVar2}=${d.col}`);
-        }
-        return thisURL;
+      if (d.url) {
+        return d.url.href;
+      }
+    })
+    .attr('xlink:target', (d) => {
+      if (d.url) {
+        return d.url.target;
       }
     })
     .append('rect')
@@ -508,11 +500,6 @@ function createViz(elem, id, rowNames, colNames, matrix, options, theme, legend,
         .delay(100)
         .duration(150)
         .style('opacity', 0)
-    })
-    .on('click', function (d) {
-      if(linkURL) {
-        tooltip.remove();
-      }
     });
 
   ////// LEGEND ////////////

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,11 +13,8 @@ import { EsnetMatrix } from './EsnetMatrix';
  * @return {*} { builder: PanelOptionsEditorBuilder<NetSageSankeyOptions> }
  */
 const OptionsCategory = ['Display'];
-const URLCategory = ['Link Options'];
 const RowOptions = ['Row/Column Options'];
 
-const urlBool = (addUrl: boolean) => (config: MatrixOptions) => config.addUrl === addUrl;
-// const eurlOtherBool = (urlOther: boolean) => (config: MatrixOptions) => config.urlOther === urlOther;
 const staticBool = (inputList: boolean) => (config: MatrixOptions) => config.inputList === inputList;
 const legendBool = (showLegend: boolean) => (config: MatrixOptions) => config.showLegend === showLegend;
 const colGroupingBool = (enableColGrouping: boolean) => (config: MatrixOptions) => config.enableColGrouping === enableColGrouping;
@@ -41,13 +38,53 @@ plugin.useFieldConfig({
   },
   disableStandardOptions: [
     FieldConfigProperty.NoValue,
-    FieldConfigProperty.Links,
   ]
 });
 
 plugin.setMigrationHandler((panel) => {
   if (panel.options.sortType === undefined) {
     panel.options.sortType = 'natural-asc'
+  }
+
+  if (panel.options.addUrl) {
+    // Migrate link configuration to a grafana data link
+    let url = panel.options.url;
+    const sourceField = panel.options.sourceField;
+    const targetField = panel.options.targetField;
+    if (url !== undefined) {
+      const variableRegex = /\w+/;
+      const urlVar1 = panel.options.urlVar1;
+      if (
+        urlVar1 !== undefined && urlVar1.match(variableRegex)
+        && sourceField !== undefined && sourceField.length >= 1
+      ) {
+        url = url.concat(
+          '&var-' + urlVar1 + '=${__data.fields["' + encodeURIComponent(sourceField) + '"]}',
+        );
+      }
+      const urlVar2 = panel.options.urlVar2;
+      if (
+        urlVar2 !== undefined && urlVar2.match(variableRegex)
+        && targetField !== undefined && targetField.length >= 1
+      ) {
+        url = url.concat(
+          '&var-' + urlVar2 + '=${__data.fields["' + encodeURIComponent(targetField) + '"]}',
+        );
+      }
+
+      if (!panel.fieldConfig.defaults.links) {
+        panel.fieldConfig.defaults.links = [];
+      }
+      panel.fieldConfig.defaults.links.push({
+        'title': 'Show details',
+        'url': url,
+      });
+    }
+
+    delete panel.options.addUrl;
+    delete panel.options.url;
+    delete panel.options.urlVar1;
+    delete panel.options.urlVar2;
   }
 
   return panel.options;
@@ -325,48 +362,4 @@ plugin.setPanelOptions((builder) => {
     category: OptionsCategory,
     defaultValue: '#E6E6E6',
   });
-
-  /////////----------- Link URL options ---------------////////////////
-  builder.addBooleanSwitch({
-    path: 'addUrl',
-    name: 'Add Data Link',
-    category: URLCategory,
-    defaultValue: false,
-  });
-  builder.addTextInput({
-    path: 'url',
-    name: 'Link URL',
-    description: 'URL to go to when square is clicked.',
-    category: URLCategory,
-    showIf: urlBool(true),
-  });
-  builder.addTextInput({
-    path: 'urlVar1',
-    name: 'Variable 1',
-    description: 'The name of the template variable to pass the source label to',
-    category: URLCategory,
-    showIf: urlBool(true),
-  });
-  builder.addTextInput({
-    path: 'urlVar2',
-    name: 'Variable 2',
-    description: 'The name of the template variable to pass the target label to',
-    category: URLCategory,
-    showIf: urlBool(true),
-  });
-  // builder.addBooleanSwitch({
-  //   path: 'urlOther',
-  //   name: 'Append more text',
-  //   description: 'Ex: date',
-  //   category: URLCategory,
-  //   defaultValue: true,
-  //   showIf: urlBool(true),
-  // });
-  // builder.addTextInput({
-  //   path: 'urlOtherText',
-  //   name: 'Text',
-  //   description: 'Other text to append to URL',
-  //   category: URLCategory,
-  //   showIf: urlOtherBool(true),
-  // });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { DisplayValue } from '@grafana/data';
+import { DisplayValue, LinkModel } from '@grafana/data';
 
 export interface MatrixOptions {
   sortType: string;
@@ -22,12 +22,10 @@ export interface MatrixOptions {
   sourceText: string;
   targetText: string;
   valueText: string;
-  addUrl: boolean;
-  url: string;
-  urlVar1: string;
-  urlVar2: string;
-  urlOther: boolean;
-  urlOtherText: string;
+  addUrl: boolean | undefined;
+  url: string | undefined;
+  urlVar1: string | undefined;
+  urlVar2: string | undefined;
   inputList: boolean;
   staticRows: string;
   staticColumns: string;
@@ -64,6 +62,7 @@ export type DataMatrixCell = {
   val: number;
   color: string;
   display: DisplayValue;
+  url: LinkModel | undefined;
 };
 
 export type LegendData = {


### PR DESCRIPTION
Currently this plugin uses a custom implementation for adding URLs to cells on the matrix. This PR replaces this custom implementation with native grafana data links, which are a lot more flexible than the current implementation.

This patch will automatically migrate existing URL configuration to a data link, so there are no breaking changes for users if this patch is merged.

Here is an example of how to configure a data link for a matrix visualisation:

<img width="1645" height="520" alt="data link config" src="https://github.com/user-attachments/assets/e85b212a-1fa2-4ac7-bcee-c72aba2154bd" />

fixes #7 